### PR TITLE
Add support for libvirt to the Vagrantfile

### DIFF
--- a/create-cluster-playbook.retry
+++ b/create-cluster-playbook.retry
@@ -1,2 +1,0 @@
-easy-kube-master
-easy-kube-node

--- a/create-cluster-playbook.retry
+++ b/create-cluster-playbook.retry
@@ -1,0 +1,2 @@
+easy-kube-master
+easy-kube-node

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -7,10 +7,8 @@ Vagrant.configure("2") do |config|
   machines = ["master", "node"]
   count = machines.size
 
-
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
-
   end
 
   config.vm.provider :libvirt do |domain|
@@ -41,7 +39,7 @@ Vagrant.configure("2") do |config|
           run: "always",
           inline: "ip r | awk '$1 == \"default\" && $5 == \"eth0\" { print $1,$2,$3 }' |  xargs --no-run-if-empty sudo ip r del"
       end
-      
+
       # Only execute once the Ansible provisioner,
       # when all the machines are up and ready.
       count -= 1

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -4,27 +4,44 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
   config.ssh.username = 'vagrant'
 
-  config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
-  end
-
   machines = ["master", "node"]
   count = machines.size
+
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+
+  end
+
+  config.vm.provider :libvirt do |domain|
+    domain.memory = 1024
+  end
+
   machines.each do |machine_id|
     config.vm.define "easy-kube-#{machine_id}" do |machine|
 
+      config.vm.provider :virtualbox do
+        machine.vm.network "public_network",
+        use_dhcp_assigned_default_route: true
+      end
+
+      config.vm.provider :libvirt do
+        machine.vm.network "private_network", type: "dhcp",
+        use_dhcp_assigned_default_route: true
+      end
+
       machine.vm.hostname = "easy-kube-#{machine_id}"
       machine.vm.box = "centos/7"
-      machine.vm.network "public_network",
-         use_dhcp_assigned_default_route: true
 
       # We want to get rid of the first default route so that ansible
       # Recognizes the second eth1 interface as ansible_default_ipv4
       # Which in this case it attached to our actual LAN network
-      machine.vm.provision "shell",
-        run: "always",
-        inline: "ip r | awk '$1 == \"default\" && $5 == \"eth0\" { print $1,$2,$3 }' |  xargs --no-run-if-empty sudo ip r del"
-
+      config.vm.provider :virtualbox do
+        machine.vm.provision "shell",
+          run: "always",
+          inline: "ip r | awk '$1 == \"default\" && $5 == \"eth0\" { print $1,$2,$3 }' |  xargs --no-run-if-empty sudo ip r del"
+      end
+      
       # Only execute once the Ansible provisioner,
       # when all the machines are up and ready.
       count -= 1
@@ -43,7 +60,6 @@ Vagrant.configure("2") do |config|
           }
         end
       end
-
     end
-  end
+ end
 end


### PR DESCRIPTION
This adds support for libvirt in addition to virtualbox, creating a private network for the master/node to run within.