### PR TITLE
Updated Vagrant file actually execute provider specifics

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,4 +1,4 @@
-ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+#ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
@@ -7,44 +7,31 @@ Vagrant.configure("2") do |config|
   machines = ["master", "node"]
   count = machines.size
 
-  config.vm.provider :virtualbox do |vb|
+  config.vm.provider "virtualbox" do |vb,override|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
+    # We want to get rid of the first default route so that ansible
+    # Recognizes the second eth1 interface as ansible_default_ipv4
+    # Which in this case it attached to our actual LAN network
+    override.vm.network "public_network",
+      use_dhcp_assigned_default_route: true
+    override.vm.provision "shell",
+      run: "always",
+      inline: "ip r | awk '$1 == \"default\" && $5 == \"eth0\" { print $1,$2,$3 }' |  xargs --no-run-if-empty sudo ip r del"
   end
 
-  config.vm.provider :libvirt do |domain|
+  config.vm.provider "libvirt" do |domain,override|
     domain.memory = 1024
+    override.vm.network "private_network", type: "dhcp",
+      use_dhcp_assigned_default_route: true
   end
 
   machines.each do |machine_id|
     config.vm.define "easy-kube-#{machine_id}" do |machine|
-
-      config.vm.provider :virtualbox do
-        machine.vm.network "public_network",
-        use_dhcp_assigned_default_route: true
-      end
-
-      config.vm.provider :libvirt do
-        machine.vm.network "private_network", type: "dhcp",
-        use_dhcp_assigned_default_route: true
-      end
-
       machine.vm.hostname = "easy-kube-#{machine_id}"
       machine.vm.box = "centos/7"
-
-      # We want to get rid of the first default route so that ansible
-      # Recognizes the second eth1 interface as ansible_default_ipv4
-      # Which in this case it attached to our actual LAN network
-      config.vm.provider :virtualbox do
-        machine.vm.provision "shell",
-          run: "always",
-          inline: "ip r | awk '$1 == \"default\" && $5 == \"eth0\" { print $1,$2,$3 }' |  xargs --no-run-if-empty sudo ip r del"
-      end
-
-      # Only execute once the Ansible provisioner,
-      # when all the machines are up and ready.
       count -= 1
       if count == 0
-        machine.vm.provision :ansible do |ansible|
+        machine.vm.provision "ansible" do |ansible|
           # Disable default limit to connect to all the machines
           ansible.limit = "all"
           ansible.sudo = true
@@ -59,5 +46,7 @@ Vagrant.configure("2") do |config|
         end
       end
     end
- end
+  end
+
+
 end


### PR DESCRIPTION
 - Overrides specify provider specific configs
 - Overrides unforutnately run after everything else
   so it's by consequence that the first master node
   which is the one that *really* needs the shell script
   is the only one that has it executed on it at the right time

Extra Notes: 

Brad's script is close, but the provider specifics he has are out of scope. 
*This is also hack* and stems from the problem where we have to run ansible very last and also we need to modify the default route on VirtualBox because vagrant insists on making the first device always the NAT network, for which incoming connections aren't supported, and for which we rely on to reach the internet. In order to circumvent this, we need to both add another device, a public device, and remove the original route so that ansible's variable `{{ ansible_default_ipv4 }}` picks up the correct address that the other hosts can contact them with. This could probably be better solved in the playbook itself, but I don't like modifying the play to suit the testing suite as it seems antithetical to the purpose of testing. Unfortunately a lot of these environments, like vagrant, aren't forgiving when you need to do something complex in multiple different providers. 

This contains a partial error in logic, in that the shell provisioner properly runs but only for all systems but the last. Vagrant deeply restricts where you can run certain things and overrides always run last in the loop, so there's zero way I could find to run overrides AND also a final provisioner for all hosts like ansible. At any rate, this works